### PR TITLE
Enhance NUMA stability and make scheduling more versatile

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ Run with `./pcsr2`
 
 # Authors
 * Eleni Alevra
-* Supervisor: Peter Pietzuch
-* Postgraduate student advisor: Dom Margan
+  * Supervisor: Peter Pietzuch
+  * Postgraduate student advisor: Dom Margan
+* Christian Menges
+  * Postgraduate student advisor: Dom Margan
+
 
 # Citation
 ```

--- a/src/benchmark.sh
+++ b/src/benchmark.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Written by Christian Menges, 10. July 2020
+
 outFile=strong_scaling_results.csv
 
 repetitions=3
@@ -20,12 +22,12 @@ for i in {0..6}; do
   t=$((2 ** i))
   line=""
   for ((r = 0; r < repetitions; r++)); do
-    output=$(./pcsr2 -threads=$t -update_file=../data/update_files/insertions.txt | sed '/Elapsed/!d' | sed -n '0~2p' | sed 's/Elapsed wall clock time: //g')
+    output=$(./parallel-packed-csr -threads=$t -update_file=../data/update_files/insertions.txt | sed '/Elapsed/!d' | sed -n '0~2p' | sed 's/Elapsed wall clock time: //g')
     line="${line},${output}"
   done
 
   for ((r = 0; r < repetitions; r++)); do
-    output=$(./pcsr2 -delete -threads=$t -update_file=../data/update_files/deletions.txt | sed '/Elapsed/!d' | sed -n '0~2p' | sed 's/Elapsed wall clock time: //g')
+    output=$(./parallel-packed-csr -delete -threads=$t -update_file=../data/update_files/deletions.txt | sed '/Elapsed/!d' | sed -n '0~2p' | sed 's/Elapsed wall clock time: //g')
     line="${line},${output}"
   done
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ using ThreadPool = ThreadPoolPPPCSR;
 using namespace std;
 
 // Reads edge list with comma separator
-vector<pair<int, int>> read_input(string filename, char delimiter = ',') {
+pair<vector<pair<int, int>>, int> read_input(string filename, char delimiter = ',') {
   ifstream f;
   string line;
   f.open(filename);
@@ -27,24 +27,27 @@ vector<pair<int, int>> read_input(string filename, char delimiter = ',') {
     exit(EXIT_FAILURE);
   }
   vector<pair<int, int>> edges;
+  int num_nodes = 0;
   while (getline(f, line)) {
     if (line.find(delimiter) == std::string::npos) {
       return read_input(filename, ' ');
     }
     int src = stoi(line.substr(0, line.find(delimiter)));
+    num_nodes = std::max(num_nodes, src);
     int target = stoi(line.substr(line.find(delimiter) + 1, line.size()));
+    num_nodes = std::max(num_nodes, target);
     edges.emplace_back(src, target);
   }
-  return edges;
+  return make_pair(edges, num_nodes);
 }
 
 // Loads core graph
-ThreadPool *insert_with_thread_pool(const vector<pair<int, int>> &input, int threads, bool lock_search) {
+ThreadPool *insert_with_thread_pool(const vector<pair<int, int>> &input, int threads, bool lock_search, int num_nodes) {
   int NUM_OF_THREADS = threads;
   if (threads < 8) {
     NUM_OF_THREADS = 8;
   }
-  ThreadPool *thread_pool = new ThreadPool(NUM_OF_THREADS, lock_search);
+  ThreadPool *thread_pool = new ThreadPool(NUM_OF_THREADS, lock_search, num_nodes);
   for (int i = 0; i < input.size(); i++) {
     thread_pool->submit_add(i % NUM_OF_THREADS, input[i].first, input[i].second);
   }
@@ -88,6 +91,7 @@ void thread_pool_deletions(ThreadPool *thread_pool, const vector<pair<int, int>>
 int main(int argc, char *argv[]) {
   int threads = 8;
   int size = 1000000;
+  int num_nodes = 0;
   bool lock_search = true;
   bool insert = true;
   vector<pair<int, int>> core_graph;
@@ -106,30 +110,38 @@ int main(int argc, char *argv[]) {
       insert = false;
     } else if (s.rfind("-core_graph=", 0) == 0) {
       string core_graph_filename = s.substr(12, s.length());
-      core_graph = read_input(core_graph_filename);
+      int temp = 0;
+      std::tie(core_graph, temp) = read_input(core_graph_filename);
+      num_nodes = std::max(num_nodes, temp);
     } else if (s.rfind("-update_file=", 0) == 0) {
       string update_filename = s.substr(13, s.length());
       cout << update_filename << endl;
-      updates = read_input(update_filename);
+      int temp = 0;
+      std::tie(updates, temp) = read_input(update_filename);
+      num_nodes = std::max(num_nodes, temp);
     }
   }
   if (core_graph.empty()) {
     cout << "Using default core graph" << endl;
-    core_graph = read_input("shuffled_higgs.txt");
+    int temp = 0;
+    std::tie(core_graph, temp) = read_input("../data/shuffled_higgs.txt");
+    num_nodes = std::max(num_nodes, temp);
   }
   if (updates.empty()) {
     cout << "Using default update graph" << endl;
-    updates = read_input("shuffled_higgs.txt");
+    int temp = 0;
+    std::tie(updates, temp) = read_input("../data/shuffled_higgs.txt");
+    num_nodes = std::max(num_nodes, temp);
   }
   cout << "Core graph size: " << core_graph.size() << endl;
   //   sort(core_graph.begin(), core_graph.end());
   // Load core graph
-  ThreadPool *thread_pool = insert_with_thread_pool(core_graph, threads, lock_search);
+  unique_ptr<ThreadPool> thread_pool(insert_with_thread_pool(core_graph, threads, lock_search, num_nodes));
   // Do updates
   if (insert) {
-    update_existing_graph(updates, thread_pool, threads, size);
+    update_existing_graph(updates, thread_pool.get(), threads, size);
   } else {
-    thread_pool_deletions(thread_pool, updates, threads, size);
+    thread_pool_deletions(thread_pool.get(), updates, threads, size);
   }
 
   // DEBUGGING CODE
@@ -147,7 +159,6 @@ int main(int argc, char *argv[]) {
   //     if (!thread_pool->pcsr->is_sorted()) {
   //       cout << "Not sorted" << endl;
   //     }
-  delete thread_pool;
 
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,9 +52,7 @@ pair<vector<pair<int, int>>, int> read_input(string filename, char delimiter = '
 ThreadPool *insert_with_thread_pool(const vector<pair<int, int>> &input, int threads, bool lock_search, int num_nodes,
                                     int partitions_per_domain) {
   int NUM_OF_THREADS = threads;
-  if (threads < 8) {
-    NUM_OF_THREADS = 8;
-  }
+
   ThreadPool *thread_pool = new ThreadPool(NUM_OF_THREADS, lock_search, num_nodes, partitions_per_domain);
   for (int i = 0; i < input.size(); i++) {
     thread_pool->submit_add(i % NUM_OF_THREADS, input[i].first, input[i].second);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,8 @@
+/**
+ * Created by Eleni Alevra
+ * modified by Christian Menges
+ */
+
 #include <bfs.h>
 
 #include <chrono>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#include <bfs.h>
+
 #include <chrono>
 #include <cmath>
 #include <ctime>
@@ -143,6 +145,13 @@ int main(int argc, char *argv[]) {
   } else {
     thread_pool_deletions(thread_pool.get(), updates, threads, size);
   }
+
+  // run BFS
+  auto start = chrono::steady_clock::now();
+  auto res = bfs(*thread_pool->pcsr, 0);
+  auto finish = chrono::steady_clock::now();
+  cout << "BFS result size: " << res.size() << std::endl;
+  cout << "BFS time size: " << chrono::duration_cast<chrono::milliseconds>(finish - start).count() << std::endl;
 
   // DEBUGGING CODE
   // Check that all edges are there and in sorted order

--- a/src/pcsr/PCSR.cpp
+++ b/src/pcsr/PCSR.cpp
@@ -14,7 +14,6 @@
 #include <atomic>
 #include <iostream>
 #include <queue>
-#include <shared_mutex>
 #include <tuple>
 #include <vector>
 

--- a/src/pcsr/PCSR.cpp
+++ b/src/pcsr/PCSR.cpp
@@ -842,6 +842,16 @@ void PCSR::read_neighbourhood(int src) {
   }
 }
 
+vector<int> PCSR::get_neighbourhood(int src) const {
+  std::vector<int> neighbours;
+  for (int i = nodes[src].beginning + 1; i < nodes[src].end; i++) {
+    if (edges.items[i].value != 0) {
+      neighbours.push_back(edges.items[i].dest);
+    }
+  }
+  return neighbours;
+}
+
 // Get id of PCSR node (starting from 0)
 // e.g. if every PCSR node has 8 elements, index number 5 is in PCSR node 0, index number 8 is in PCSR node 1 etc.
 // Added by Eleni Alevra
@@ -1374,4 +1384,23 @@ void PCSR::add_edge_parallel(uint32_t src, uint32_t dest, uint32_t value, int re
       free(acquired_locks.second);
     }
   }
+}
+
+void PCSR::insert_nodes_and_edges_front(std::vector<node_t> new_nodes, std::vector<edge_t> new_edges) {
+
+}
+
+void PCSR::insert_nodes_and_edges_back(std::vector<node_t> new_nodes, std::vector<edge_t> new_edges) {
+
+}
+
+std::pair<std::vector<node_t>, std::vector<edge_t>> PCSR::remove_nodes_and_edges_front(int num_nodes) {
+  std::vector<node_t> exported_nodes;
+  std::vector<edge_t> exported_edges;
+  return make_pair(exported_nodes, exported_edges);
+}
+std::pair<std::vector<node_t>, std::vector<edge_t>> PCSR::remove_nodes_and_edges_back(int num_nodes) {
+  std::vector<node_t> exported_nodes;
+  std::vector<edge_t> exported_edges;
+  return make_pair(exported_nodes, exported_edges);
 }

--- a/src/pcsr/PCSR.cpp
+++ b/src/pcsr/PCSR.cpp
@@ -1,6 +1,7 @@
 /**
  * This file was cloned from https://github.com/wheatman/Packed-Compressed-Sparse-Row/. The
  * parts of the code that Eleni Alevra has added for the parallel version are marked by comments.
+ * modified by Christian Menges
  */
 #include "PCSR.h"
 

--- a/src/pcsr/PCSR.cpp
+++ b/src/pcsr/PCSR.cpp
@@ -96,32 +96,6 @@ vector<tuple<uint32_t, uint32_t, uint32_t>> PCSR::get_edges() {
   return output;
 }
 
-vector<uint32_t> PCSR::bfs(uint32_t start_node) {
-  uint64_t n = get_n();
-  vector<uint32_t> out(n, UINT32_MAX);
-  queue<uint32_t> next;
-  next.push(start_node);
-  out[start_node] = 0;
-
-  while (!next.empty()) {
-    uint32_t active = next.front();
-    next.pop();
-
-    uint32_t start = nodes[active].beginning;
-    uint32_t end = nodes[active].end;
-
-    // get neighbors
-    // start at +1 for the sentinel
-    for (int j = start + 1; j < end; j++) {
-      if (!is_null(edges.items[j].value) && out[edges.items[j].dest] == UINT32_MAX) {
-        next.push(edges.items[j].dest);
-        out[edges.items[j].dest] = out[active] + 1;
-      }
-    }
-  }
-  return out;
-}
-
 uint64_t PCSR::get_n() { return nodes.size(); }
 
 uint64_t PCSR::get_size() {

--- a/src/pcsr/PCSR.h
+++ b/src/pcsr/PCSR.h
@@ -96,7 +96,6 @@ class PCSR {
   uint32_t find_value(uint32_t src, uint32_t dest);
   vector<uint32_t> sparse_matrix_vector_multiplication(std::vector<uint32_t> const &v);
   vector<float> pagerank(std::vector<float> const &node_values);
-  vector<uint32_t> bfs(uint32_t start_node);
   void double_list();
   void half_list();
   int slide_right(int index, uint32_t src);

--- a/src/pcsr/PCSR.h
+++ b/src/pcsr/PCSR.h
@@ -1,6 +1,8 @@
-//
-// Created by Eleni Alevra on 02/06/2020.
-//
+/*
+ * Created by Eleni Alevra on 02/06/2020.
+ * modified by Christian Menges
+ */
+
 #include <atomic>
 #include <shared_mutex>
 #include <vector>

--- a/src/pcsr/PCSR.h
+++ b/src/pcsr/PCSR.h
@@ -70,6 +70,53 @@ class PCSR {
   void add_edge(uint32_t src, uint32_t dest, uint32_t value);
   void remove_edge(uint32_t src, uint32_t dest);
   void read_neighbourhood(int src);
+  vector<int> get_neighbourhood(int src) const;
+
+  /**
+   * Returns the node count
+   * @return node count
+   */
+  uint64_t get_n();
+
+  /**
+   * inserts nodes and edges at the front ot the data structure
+   * @param nodes
+   * @param new_items
+   */
+  void insert_nodes_and_edges_front(std::vector<node_t> nodes, std::vector<edge_t> new_edges);
+
+  /**
+   * inserts nodes and edges at the end ot the data structure
+   * @param nodes
+   * @param new_items
+   */
+  void insert_nodes_and_edges_back(std::vector<node_t> nodes, std::vector<edge_t> new_edges);
+
+  /**
+   * removes nodes and edges at the front ot the data structure
+   * @param num_nodes #nodes to remove
+   * @return removed nodes and edges
+   */
+  std::pair<std::vector<node_t>, std::vector<edge_t>> remove_nodes_and_edges_front(int num_nodes);
+
+  /**
+   * removes nodes and edges at the end ot the data structure
+   * @param num_nodes
+   * @return removed nodes and edges
+   */
+  std::pair<std::vector<node_t>, std::vector<edge_t>> remove_nodes_and_edges_back(int num_nodes);
+
+  /**
+   * Returns a ref. to the node with the given id
+   * @return ref. to node
+   */
+  node_t &getNode(int id) { return nodes[id]; }
+
+  /**
+   * Returns a const ref. to the node with the given id
+   * @return const ref. to node
+   */
+  const node_t &getNode(int id) const { return nodes[id]; }
 
  private:
   // data members
@@ -108,12 +155,38 @@ class PCSR {
   void print_graph(int);
   pair<double, int> redistr_store(edge_t *space, int index, int len);
   void fix_sentinel(int32_t node_index, int in);
+  /**
+   * Returns total number of edges in range [index, index + len)
+   * @param index start index
+   * @param len range length
+   * @return #edges in range
+   */
   int count_elems(int index, int len);
+  /**
+   * Returns true if every neighbourhood is sorted
+   * @return sorted
+   */
   bool is_sorted();
+  /**
+   * Returns the total number of stored edges
+   * @return #edges
+   */
   int count_total_edges();
+  /**
+   * Return the memory footprint of this data structure in byte
+   * @return memory footprint in byte
+   */
   uint64_t get_size();
-  uint64_t get_n();
+
+  /**
+   * Returns all stored edges
+   * @return [{node_id, dest_id, edge_value}]
+   */
   vector<tuple<uint32_t, uint32_t, uint32_t>> get_edges();
+
+  /**
+   * Deletes all edges. The data structure is invalid afterwards
+   */
   void clear();
 };
 

--- a/src/pcsr/PCSR.h
+++ b/src/pcsr/PCSR.h
@@ -192,6 +192,7 @@ class PCSR {
   void clear();
 
   int domain;
+  const bool is_numa_available;
 };
 
 #endif  // PCSR2_PCSR_H

--- a/src/pcsr/PCSR.h
+++ b/src/pcsr/PCSR.h
@@ -188,6 +188,8 @@ class PCSR {
    * Deletes all edges. The data structure is invalid afterwards
    */
   void clear();
+
+  int domain;
 };
 
 #endif  // PCSR2_PCSR_H

--- a/src/pppcsr/PPPCSR.cpp
+++ b/src/pppcsr/PPPCSR.cpp
@@ -1,6 +1,7 @@
-//
-// Created by menges on 7/7/20.
-//
+/**
+ * @file PPPCSR.cpp
+ * @author Christian Menges
+ */
 
 #include "PPPCSR.h"
 

--- a/src/pppcsr/PPPCSR.cpp
+++ b/src/pppcsr/PPPCSR.cpp
@@ -14,7 +14,7 @@ PPPCSR::PPPCSR(uint32_t init_n, uint32_t src_n, bool lock_search) {
   if (numa_available() < 0) {
     std::cout << "NUMA not available. Using single partition\n";
   } else {
-    numPartitions = numa_max_node() + 2;
+    numPartitions = numa_max_node() + 1;
   }
   partitions.reserve(numPartitions);
   distribution.reserve(numPartitions);
@@ -35,6 +35,10 @@ bool PPPCSR::edge_exists(uint32_t src, uint32_t dest) {
   return partitions[get_partiton(src)].edge_exists(src - distribution[get_partiton(src)], dest);
 }
 
+vector<int> PPPCSR::get_neighbourhood(int src) const {
+  return partitions[get_partiton(src)].get_neighbourhood(src - distribution[get_partiton(src)]);
+}
+
 void PPPCSR::add_node() { partitions.back().add_node(); }
 
 void PPPCSR::add_edge(uint32_t src, uint32_t dest, uint32_t value) {
@@ -49,7 +53,7 @@ void PPPCSR::read_neighbourhood(int src) {
   partitions[get_partiton(src)].read_neighbourhood(src - distribution[get_partiton(src)]);
 }
 
-std::size_t PPPCSR::get_partiton(size_t vertex_id) {
+std::size_t PPPCSR::get_partiton(size_t vertex_id) const {
   for (std::size_t i = 1; i < distribution.size(); i++) {
     if (distribution[i] > vertex_id) {
       return i - 1;
@@ -57,4 +61,12 @@ std::size_t PPPCSR::get_partiton(size_t vertex_id) {
   }
   // Return last partition
   return distribution.size() - 1;
+}
+
+uint64_t PPPCSR::get_n() {
+  uint64_t n = 0;
+  for (int i = 0; i < partitions.size(); i++) {
+    n += partitions[i].get_n();
+  }
+  return n;
 }

--- a/src/pppcsr/PPPCSR.h
+++ b/src/pppcsr/PPPCSR.h
@@ -1,6 +1,7 @@
-//
-// Created by menges on 7/7/20.
-//
+/**
+ * @file PPPCSR.h
+ * @author Christian Menges
+ */
 
 #include "../pcsr/PCSR.h"
 

--- a/src/pppcsr/PPPCSR.h
+++ b/src/pppcsr/PPPCSR.h
@@ -13,7 +13,7 @@ class PPPCSR {
   // data members
   edge_list_t edges;
 
-  PPPCSR(uint32_t init_n, uint32_t, bool lock_search);
+  PPPCSR(uint32_t init_n, uint32_t, bool lock_search, int partitionsPerDomain);
   //    PPPCSR(uint32_t init_n, vector<condition_variable*> *cvs, bool search_lock);
   //    ~PPPCSR();
   /** Public API */
@@ -39,6 +39,8 @@ class PPPCSR {
 
   /// start index vertices in the partitions
   std::vector<size_t> distribution;
+
+  int partitionsPerDomain;
 };
 
 #endif  // PPPCSR_H

--- a/src/pppcsr/PPPCSR.h
+++ b/src/pppcsr/PPPCSR.h
@@ -22,7 +22,15 @@ class PPPCSR {
   void remove_edge(uint32_t src, uint32_t dest);
   void read_neighbourhood(int src);
 
-  std::size_t get_partiton(size_t vertex_id);
+  std::size_t get_partiton(size_t vertex_id) const;
+
+  vector<int> get_neighbourhood(int src) const;
+
+  /**
+   * Returns the node count
+   * @return node count
+   */
+  uint64_t get_n();
 
  private:
   /// different partitions

--- a/src/thread_pool/thread_pool.cpp
+++ b/src/thread_pool/thread_pool.cpp
@@ -15,9 +15,9 @@ using namespace std;
 /**
  * Initializes a pool of threads. Every thread has its own task queue.
  */
-ThreadPool::ThreadPool(const int NUM_OF_THREADS, bool lock_search) {
+ThreadPool::ThreadPool(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes) {
   tasks.resize(NUM_OF_THREADS);
-  pcsr = new PCSR(456627.0, 456627.0, lock_search);
+  pcsr = new PCSR(init_num_nodes, init_num_nodes, lock_search);
 }
 
 // Function executed by worker threads

--- a/src/thread_pool/thread_pool.cpp
+++ b/src/thread_pool/thread_pool.cpp
@@ -1,6 +1,8 @@
-//
-// Created by Eleni Alevra on 29/03/2020.
-//
+/**
+ * Created by Eleni Alevra on 29/03/2020.
+ * modified by Christian Menges
+ */
+
 
 #include "thread_pool.h"
 

--- a/src/thread_pool/thread_pool.cpp
+++ b/src/thread_pool/thread_pool.cpp
@@ -3,7 +3,6 @@
  * modified by Christian Menges
  */
 
-
 #include "thread_pool.h"
 
 #include <ctime>
@@ -17,7 +16,7 @@ using namespace std;
 /**
  * Initializes a pool of threads. Every thread has its own task queue.
  */
-ThreadPool::ThreadPool(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes) {
+ThreadPool::ThreadPool(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes, int partitions_per_domain) {
   tasks.resize(NUM_OF_THREADS);
   pcsr = new PCSR(init_num_nodes, init_num_nodes, lock_search);
 }

--- a/src/thread_pool/thread_pool.h
+++ b/src/thread_pool/thread_pool.h
@@ -1,6 +1,7 @@
-//
-// Created by Eleni Alevra on 02/06/2020.
-//
+/**
+ * Created by Eleni Alevra on 02/06/2020.
+ * modified by Christian Menges
+ */
 
 #include <queue>
 #include <thread>

--- a/src/thread_pool/thread_pool.h
+++ b/src/thread_pool/thread_pool.h
@@ -24,8 +24,9 @@ class ThreadPool {
  public:
   PCSR *pcsr;
 
-  explicit ThreadPool(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes);
-  ~ThreadPool() {}
+  explicit ThreadPool(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes, int partitions_per_domain);
+  ~ThreadPool() = default;
+
   /** Public API */
   void submit_add(int thread_id, int src, int dest);     // submit task to thread {thread_id} to insert edge {src, dest}
   void submit_delete(int thread_id, int src, int dest);  // submit task to thread {thread_id} to delete edge {src, dest}

--- a/src/thread_pool/thread_pool.h
+++ b/src/thread_pool/thread_pool.h
@@ -23,7 +23,7 @@ class ThreadPool {
  public:
   PCSR *pcsr;
 
-  explicit ThreadPool(const int NUM_OF_THREADS, bool lock_search);
+  explicit ThreadPool(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes);
   ~ThreadPool() {}
   /** Public API */
   void submit_add(int thread_id, int src, int dest);     // submit task to thread {thread_id} to insert edge {src, dest}

--- a/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
+++ b/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
@@ -53,7 +53,8 @@ void ThreadPoolPPPCSR::submit_add(int thread_id, int src, int target) {
   static int par2 = 0;
   auto par = pcsr->get_partiton(src);
   if (par == 0) {
-    tasks[par1 % (int)std::ceil(tasks.size() / (numa_max_node() + 1))].push(task{true, false, src, target});
+    tasks[par1 % (int)std::ceil(tasks.size() / (numa_max_node() + 1))]
+    .push(task{true, false, src, target});
     par1++;
   } else {
     tasks[(std::ceil(tasks.size() / (numa_max_node() + 1))) +
@@ -65,7 +66,19 @@ void ThreadPoolPPPCSR::submit_add(int thread_id, int src, int target) {
 
 // Submit a delete edge task for edge {src, target} to thread with number thread_id
 void ThreadPoolPPPCSR::submit_delete(int thread_id, int src, int target) {
-  tasks[thread_id].push(task{false, false, src, target});
+    static int par1 = 0;
+    static int par2 = 0;
+    auto par = pcsr->get_partiton(src);
+    if (par == 0) {
+        tasks[par1 % (int)std::ceil(tasks.size() / (numa_max_node() + 1))]
+        .push(task{false, false, src, target});;
+        par1++;
+    } else {
+        tasks[(std::ceil(tasks.size() / (numa_max_node() + 1))) +
+              par2 % (int)std::ceil(tasks.size() / (numa_max_node() + 1))]
+                .push(task{false, false, src, target});;
+        par2++;
+    }
 }
 
 // Submit a read neighbourhood task for vertex src to thread with number thread_id

--- a/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
+++ b/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
@@ -19,9 +19,9 @@ using namespace std;
 /**
  * Initializes a pool of threads. Every thread has its own task queue.
  */
-ThreadPoolPPPCSR::ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search) {
+ThreadPoolPPPCSR::ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes) {
   tasks.resize(NUM_OF_THREADS);
-  pcsr = new PPPCSR(456627.0, 456627.0, lock_search);
+  pcsr = new PPPCSR(init_num_nodes, init_num_nodes, lock_search);
 }
 
 // Function executed by worker threads

--- a/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
+++ b/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
@@ -1,6 +1,7 @@
-//
-// Created by Christian Menges.
-//
+/**
+ * @file thread_pool_pppcsr.cpp
+ * @author Christian Menges
+ */
 
 #include "thread_pool_pppcsr.h"
 

--- a/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
+++ b/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
@@ -30,7 +30,7 @@ ThreadPoolPPPCSR::ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search, u
 // Finishes when finished is set to true and there are no outstanding tasks
 void ThreadPoolPPPCSR::execute(int thread_id) {
   cout << "Thread " << thread_id << " has " << tasks[thread_id].size() << " tasks" << endl;
-  if (numa_available()) {
+  if (numa_available() >= 0) {
     numa_run_on_node(thread_id / (std::ceil(tasks.size() / (numa_max_node() + 1))));
   }
   while (!finished || !tasks[thread_id].empty()) {

--- a/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
+++ b/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
@@ -33,9 +33,9 @@ ThreadPoolPPPCSR::ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search, u
 // Does insertions, deletions and reads on the PCSR
 // Finishes when finished is set to true and there are no outstanding tasks
 void ThreadPoolPPPCSR::execute(int thread_id) {
-  cout << "Thread " << thread_id << " has " << tasks[thread_id].size() << " tasks, runs on domain " << (thread_id ) / (tasks.size() / available_nodes) << endl;
+  cout << "Thread " << thread_id << " has " << tasks[thread_id].size() << " tasks, runs on domain " << (thread_id ) / std::max(1ul, tasks.size() / available_nodes) << endl;
   if (numa_available() >= 0) {
-    numa_run_on_node((thread_id ) / (tasks.size() / available_nodes));
+    numa_run_on_node((thread_id ) / std::max(1ul, tasks.size() / available_nodes));
   }
   while (!finished || !tasks[thread_id].empty()) {
     if (!tasks[thread_id].empty()) {
@@ -55,7 +55,7 @@ void ThreadPoolPPPCSR::execute(int thread_id) {
 // Submit an update for edge {src, target} to thread with number thread_id
 void ThreadPoolPPPCSR::submit_add(int thread_id, int src, int target) {
   auto par = pcsr->get_partiton(src);
-  auto index = (indeces[par]++)%(tasks.size() / available_nodes);
+  auto index = (indeces[par]++)%(std::max(1ul,tasks.size() / available_nodes));
     tasks[(par / partitions_per_domain) * (tasks.size() / available_nodes) + index]
     .push(task{true, false, src, target});
 }
@@ -63,7 +63,7 @@ void ThreadPoolPPPCSR::submit_add(int thread_id, int src, int target) {
 // Submit a delete edge task for edge {src, target} to thread with number thread_id
 void ThreadPoolPPPCSR::submit_delete(int thread_id, int src, int target) {
     auto par = pcsr->get_partiton(src);
-    auto index = (indeces[par]++)%(tasks.size() / available_nodes);
+    auto index = (indeces[par]++)%(std::max(1ul,tasks.size() / available_nodes));
     tasks[(par / partitions_per_domain) * (tasks.size() / available_nodes) + index]
             .push(task{false, false, src, target});
 }
@@ -71,7 +71,7 @@ void ThreadPoolPPPCSR::submit_delete(int thread_id, int src, int target) {
 // Submit a read neighbourhood task for vertex src to thread with number thread_id
 void ThreadPoolPPPCSR::submit_read(int thread_id, int src) {
     auto par = pcsr->get_partiton(src);
-    auto index = (indeces[par]++) % (tasks.size() / available_nodes);
+    auto index = (indeces[par]++) % (std::max(1ul,tasks.size() / available_nodes));
     tasks[(par / partitions_per_domain) * (tasks.size() / available_nodes) + index]
             .push(task{false, true, src, src});
 }

--- a/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
+++ b/src/thread_pool_pppcsr/thread_pool_pppcsr.cpp
@@ -20,18 +20,22 @@ using namespace std;
 /**
  * Initializes a pool of threads. Every thread has its own task queue.
  */
-ThreadPoolPPPCSR::ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes) {
+ThreadPoolPPPCSR::ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes, int partitions_per_domain) :
+        available_nodes(numa_max_node()+1),
+        partitions_per_domain(partitions_per_domain)
+{
   tasks.resize(NUM_OF_THREADS);
-  pcsr = new PPPCSR(init_num_nodes, init_num_nodes, lock_search);
+  indeces.resize(available_nodes * partitions_per_domain, 0);
+  pcsr = new PPPCSR(init_num_nodes, init_num_nodes, lock_search, partitions_per_domain);
 }
 
 // Function executed by worker threads
 // Does insertions, deletions and reads on the PCSR
 // Finishes when finished is set to true and there are no outstanding tasks
 void ThreadPoolPPPCSR::execute(int thread_id) {
-  cout << "Thread " << thread_id << " has " << tasks[thread_id].size() << " tasks" << endl;
+  cout << "Thread " << thread_id << " has " << tasks[thread_id].size() << " tasks, runs on domain " << (thread_id ) / (tasks.size() / available_nodes) << endl;
   if (numa_available() >= 0) {
-    numa_run_on_node(thread_id / (std::ceil(tasks.size() / (numa_max_node() + 1))));
+    numa_run_on_node((thread_id ) / (tasks.size() / available_nodes));
   }
   while (!finished || !tasks[thread_id].empty()) {
     if (!tasks[thread_id].empty()) {
@@ -50,40 +54,27 @@ void ThreadPoolPPPCSR::execute(int thread_id) {
 
 // Submit an update for edge {src, target} to thread with number thread_id
 void ThreadPoolPPPCSR::submit_add(int thread_id, int src, int target) {
-  static int par1 = 0;
-  static int par2 = 0;
   auto par = pcsr->get_partiton(src);
-  if (par == 0) {
-    tasks[par1 % (int)std::ceil(tasks.size() / (numa_max_node() + 1))]
+  auto index = (indeces[par]++)%(tasks.size() / available_nodes);
+    tasks[(par / partitions_per_domain) * (tasks.size() / available_nodes) + index]
     .push(task{true, false, src, target});
-    par1++;
-  } else {
-    tasks[(std::ceil(tasks.size() / (numa_max_node() + 1))) +
-          par2 % (int)std::ceil(tasks.size() / (numa_max_node() + 1))]
-        .push(task{true, false, src, target});
-    par2++;
-  }
 }
 
 // Submit a delete edge task for edge {src, target} to thread with number thread_id
 void ThreadPoolPPPCSR::submit_delete(int thread_id, int src, int target) {
-    static int par1 = 0;
-    static int par2 = 0;
     auto par = pcsr->get_partiton(src);
-    if (par == 0) {
-        tasks[par1 % (int)std::ceil(tasks.size() / (numa_max_node() + 1))]
-        .push(task{false, false, src, target});;
-        par1++;
-    } else {
-        tasks[(std::ceil(tasks.size() / (numa_max_node() + 1))) +
-              par2 % (int)std::ceil(tasks.size() / (numa_max_node() + 1))]
-                .push(task{false, false, src, target});;
-        par2++;
-    }
+    auto index = (indeces[par]++)%(tasks.size() / available_nodes);
+    tasks[(par / partitions_per_domain) * (tasks.size() / available_nodes) + index]
+            .push(task{false, false, src, target});
 }
 
 // Submit a read neighbourhood task for vertex src to thread with number thread_id
-void ThreadPoolPPPCSR::submit_read(int thread_id, int src) { tasks[thread_id].push(task{false, true, src, src}); }
+void ThreadPoolPPPCSR::submit_read(int thread_id, int src) {
+    auto par = pcsr->get_partiton(src);
+    auto index = (indeces[par]++) % (tasks.size() / available_nodes);
+    tasks[(par / partitions_per_domain) * (tasks.size() / available_nodes) + index]
+            .push(task{false, true, src, src});
+}
 
 // starts a new number of threads
 // number of threads is passed to the constructor

--- a/src/thread_pool_pppcsr/thread_pool_pppcsr.h
+++ b/src/thread_pool_pppcsr/thread_pool_pppcsr.h
@@ -1,6 +1,7 @@
-//
-// Created by Christian Menges.
-//
+/**
+ * @file thread_pool_pppcsr.h
+ * @author Christian Menges
+ */
 
 #include <queue>
 #include <thread>

--- a/src/thread_pool_pppcsr/thread_pool_pppcsr.h
+++ b/src/thread_pool_pppcsr/thread_pool_pppcsr.h
@@ -23,7 +23,7 @@ class ThreadPoolPPPCSR {
  public:
   PPPCSR *pcsr;
 
-  explicit ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search);
+  explicit ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes);
   ~ThreadPoolPPPCSR() {}
   /** Public API */
   void submit_add(int thread_id, int src, int dest);     // submit task to thread {thread_id} to insert edge {src, dest}

--- a/src/thread_pool_pppcsr/thread_pool_pppcsr.h
+++ b/src/thread_pool_pppcsr/thread_pool_pppcsr.h
@@ -24,8 +24,8 @@ class ThreadPoolPPPCSR {
  public:
   PPPCSR *pcsr;
 
-  explicit ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes);
-  ~ThreadPoolPPPCSR() {}
+  explicit ThreadPoolPPPCSR(const int NUM_OF_THREADS, bool lock_search, uint32_t init_num_nodes, int partitions_per_domain);
+  ~ThreadPoolPPPCSR() = default;
   /** Public API */
   void submit_add(int thread_id, int src, int dest);     // submit task to thread {thread_id} to insert edge {src, dest}
   void submit_delete(int thread_id, int src, int dest);  // submit task to thread {thread_id} to delete edge {src, dest}
@@ -41,6 +41,10 @@ class ThreadPoolPPPCSR {
   bool finished = false;
 
   void execute(int);
+
+  const int available_nodes;
+  std::vector<unsigned> indeces;
+  int partitions_per_domain = 1;
 };
 
 #endif  // PPPCSR_THREAD_POOL_H

--- a/src/utility/bfs.h
+++ b/src/utility/bfs.h
@@ -1,0 +1,39 @@
+//
+// Created by menges on 7/20/20.
+//
+
+#include <vector>
+
+using namespace std;
+
+#ifndef PARALLEL_PACKED_CSR_BFS_H
+#define PARALLEL_PACKED_CSR_BFS_H
+
+template<typename T>
+vector<uint32_t> bfs(T &graph, uint32_t start_node) {
+    uint64_t n = graph.get_n();
+    vector<uint32_t> out(n, UINT32_MAX);
+    queue<uint32_t> next;
+    next.push(start_node);
+    out[start_node] = 0;
+
+    while (!next.empty()) {
+        uint32_t active = next.front();
+        next.pop();
+
+        uint32_t start = graph.nodes[active].beginning;
+        uint32_t end = graph.nodes[active].end;
+
+        // get neighbors
+        // start at +1 for the sentinel
+        for (int j = start + 1; j < end; j++) {
+            if (!(graph.edges.items[j].value == 0) && out[graph.edges.items[j].dest] == UINT32_MAX) {
+                next.push(graph.edges.items[j].dest);
+                out[graph.edges.items[j].dest] = out[active] + 1;
+            }
+        }
+    }
+    return out;
+}
+
+#endif //PARALLEL_PACKED_CSR_BFS_H

--- a/src/utility/bfs.h
+++ b/src/utility/bfs.h
@@ -2,6 +2,8 @@
 // Created by menges on 7/20/20.
 //
 
+#include <cstdint>
+#include <queue>
 #include <vector>
 
 using namespace std;
@@ -9,31 +11,27 @@ using namespace std;
 #ifndef PARALLEL_PACKED_CSR_BFS_H
 #define PARALLEL_PACKED_CSR_BFS_H
 
-template<typename T>
+template <typename T>
 vector<uint32_t> bfs(T &graph, uint32_t start_node) {
-    uint64_t n = graph.get_n();
-    vector<uint32_t> out(n, UINT32_MAX);
-    queue<uint32_t> next;
-    next.push(start_node);
-    out[start_node] = 0;
+  uint64_t n = graph.get_n();
+  vector<uint32_t> out(n, UINT32_MAX);
+  queue<uint32_t> next;
+  next.push(start_node);
+  out[start_node] = 0;
 
-    while (!next.empty()) {
-        uint32_t active = next.front();
-        next.pop();
+  while (!next.empty()) {
+    uint32_t active = next.front();
+    next.pop();
 
-        uint32_t start = graph.nodes[active].beginning;
-        uint32_t end = graph.nodes[active].end;
-
-        // get neighbors
-        // start at +1 for the sentinel
-        for (int j = start + 1; j < end; j++) {
-            if (!(graph.edges.items[j].value == 0) && out[graph.edges.items[j].dest] == UINT32_MAX) {
-                next.push(graph.edges.items[j].dest);
-                out[graph.edges.items[j].dest] = out[active] + 1;
-            }
-        }
+    // get neighbors
+    for (const int neighbour : graph.get_neighbourhood(active)) {
+      if (out[neighbour] == UINT32_MAX) {
+        next.push(neighbour);
+        out[neighbour] = out[active] + 1;
+      }
     }
-    return out;
+  }
+  return out;
 }
 
-#endif //PARALLEL_PACKED_CSR_BFS_H
+#endif  // PARALLEL_PACKED_CSR_BFS_H


### PR DESCRIPTION
The schedular is no longer limited to two NUMA domains and the number of partitions per NUMA domain can be adjusted by the CLI option `partitions_per_domain`