### PR TITLE
In-place redistribute / half_list

### DIFF
--- a/src/pcsr/PCSR.cpp
+++ b/src/pcsr/PCSR.cpp
@@ -60,7 +60,7 @@ int find_node(int index, int len) { return (index / len) * len; }
 // null overrides sentinel
 // e.g. in rebalance, we check if an edge is null
 // first before copying it into temp, then fix the sentinels.
-bool is_sentinel(edge_t e) { return e.dest == UINT32_MAX || e.value == UINT32_MAX; }
+bool is_sentinel(const edge_t &e) { return e.dest == UINT32_MAX || e.value == UINT32_MAX; }
 
 // bool is_null(edge_t e) { return e.value == 0; }
 
@@ -398,7 +398,7 @@ void PCSR::slide_left(int index, uint32_t src) {
 int find_leaf(edge_list_t *list, int index) { return (index / list->logN) * list->logN; }
 
 // true if e1, e2 are equals
-bool edge_equals(edge_t e1, edge_t e2) { return e1.dest == e2.dest && e1.value == e2.value; }
+bool edge_equals(const edge_t &e1, const edge_t &e2) { return e1.dest == e2.dest && e1.value == e2.value; }
 
 // return index of the edge elem
 // takes in edge list and place to start looking

--- a/src/pcsr/PCSR.cpp
+++ b/src/pcsr/PCSR.cpp
@@ -161,6 +161,9 @@ pair_double density_bound(edge_list_t *list, int depth) {
 
 // fix pointer from node to moved sentinel
 void PCSR::fix_sentinel(const edge_t &sentinel, int in) {
+  if (!is_sentinel(sentinel)) {
+    return;
+  }
   uint32_t node_index = sentinel.value;
 
   if (node_index == UINT32_MAX) {
@@ -234,16 +237,10 @@ void PCSR::redistribute(int index, int len) {
     const size_t in = static_cast<size_t>(index_d);
 
     std::swap(edges.items[in], edges.items[i]);
-    if (is_sentinel(edges.items[in])) {
-      // fixing pointer of node that goes to this sentinel
-      fix_sentinel(edges.items[in], in);
-    }
+    fix_sentinel(edges.items[in], in);
     index_d -= step;
   }
-  if (is_sentinel(edges.items[index])) {
-    // fixing pointer of node that goes to this sentinel
-    fix_sentinel(edges.items[index], index);
-  }
+  fix_sentinel(edges.items[index], index);
 }
 
 void PCSR::double_list() {
@@ -341,14 +338,14 @@ int PCSR::slide_right(int index, uint32_t src) {
   while (index < edges.N && !is_null(edges.items[index].value)) {
     edge_t temp = edges.items[index];
     edges.items[index] = el;
-    if (!is_null(el.value) && is_sentinel(el)) {
+    if (!is_null(el.value)) {
       // fixing pointer of node that goes to this sentinel
       fix_sentinel(el, index);
     }
     el = temp;
     index++;
   }
-  if (!is_null(el.value) && is_sentinel(el)) {
+  if (!is_null(el.value)) {
     // fixing pointer of node that goes to this sentinel
     fix_sentinel(el, index);
   }
@@ -375,7 +372,7 @@ void PCSR::slide_left(int index, uint32_t src) {
   while (index >= 0 && !is_null(edges.items[index].value)) {
     edge_t temp = edges.items[index];
     edges.items[index] = el;
-    if (!is_null(el.value) && is_sentinel(el)) {
+    if (!is_null(el.value)) {
       // fixing pointer of node that goes to this sentinel
       fix_sentinel(el, index);
     }
@@ -389,7 +386,7 @@ void PCSR::slide_left(int index, uint32_t src) {
     slide_right(0, src);
     index = 0;
   }
-  if (!is_null(el.value) && is_sentinel(el)) {
+  if (!is_null(el.value)) {
     // fixing pointer of node that goes to this sentinel
     fix_sentinel(el, index);
   }

--- a/src/pcsr/PCSR.h
+++ b/src/pcsr/PCSR.h
@@ -33,7 +33,7 @@ typedef struct _edge {
 } edge_t;
 
 typedef struct edge_list {
-  int N;
+  uint64_t N;
   int H;
   int logN;
   shared_ptr<HybridLock> global_lock;
@@ -194,8 +194,8 @@ class PCSR {
 
   void nodes_unlock_shared(bool unlock, int start_node, int end_node);
 
-  int domain;
   const bool is_numa_available;
+  int domain;
 };
 
 #endif  // PCSR2_PCSR_H


### PR DESCRIPTION
This PR implements an in-place version of edge redistribution and improves half_list by avoiding the creation of a second edge array. Also, various types were replaced by `auto` to improve maintainability and reduce compiler warnings (there are still a lot of them).